### PR TITLE
Reference to child_pop instead of parent_pop

### DIFF
--- a/src/omniopt.c
+++ b/src/omniopt.c
@@ -296,7 +296,7 @@ SEXP omnioptC(
                 // convert to SEXP
                 SEXP xbinr = PROTECT(allocVector(INTSXP, nbin));
                 for (int k = 0; k < nbin; ++k) {
-                  INTEGER(xbinr)[k] = parent_pop->ind[i].gene[k][0];
+                  INTEGER(xbinr)[k] = child_pop->ind[i].gene[k][0];
                 }
 
                 SEXP call = PROTECT(LCONS(fun, LCONS(xbinr, R_NilValue)));
@@ -304,11 +304,11 @@ SEXP omnioptC(
 
                 // update indiviual
                 for (int j = 0; j < nobj; ++j) {
-                  parent_pop->ind[i].obj[j] = REAL(retu)[j];
+                  child_pop->ind[i].obj[j] = REAL(retu)[j];
                 }
 
                 // we do not deal with constraint problems
-                parent_pop->ind[i].constr_violation = 0.0;
+                child_pop->ind[i].constr_violation = 0.0;
 
                 // drop garbage collector protection
                 UNPROTECT(2);


### PR DESCRIPTION
This fixes issues when running omnioptr with binary decision spaces, as the parent population is lost in the process.

For reference, see alternative if-statement above that also references child_pop in the real-valued case.


I hacked together a small demonstrator.

Before:

![before](https://github.com/jakobbossek/omnioptr/assets/36477576/0788e24c-dea7-4ab4-8ffd-85743f420bbb)


After:

![after](https://github.com/jakobbossek/omnioptr/assets/36477576/97484593-f706-40bd-822d-fe4d50a90d56)


Code:

```r
library(omnioptr)
library(tidyverse)

D <- 10

fn <- smoof::makeBiObjBBOBFunction(D, 10, 1)

fn_internal <- function(x) {
  out <- fn(as.numeric(x))
  out
}

fn_bin <- smoof::makeMultiObjectiveFunction(
  "fn_bin", "fn_bin", fn = fn_internal,
  par.set = makeParamSet(makeIntegerVectorParam("x", D, lower = rep(0, D), upper = rep(1, D))),
  n.objectives = 2
)

omni_out <- omniopt(fn_bin, pop.size = 100L, n.gens = 21L, frequency = 2L)
# omni_out

lapply(1:length(omni_out$history), function(i) {
  df <- cbind.data.frame(t(omni_out$history[[i]]$obj), i = i)
  colnames(df) <- c("y1", "y2", "i")
  
  df
}) %>% Reduce(rbind, .) %>% 
  ggplot(aes(y1, y2, color = factor(i))) +
  geom_point()
```


So, to me the problem seems to be fixed now!

Best,
Lennart